### PR TITLE
added support for different styles extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-typed-css-modules",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Generate type definition files for css modules",
   "main": "dist/index.js",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,12 @@
-import type { Plugin, UserConfig } from "vite";
+import type { PluginOption, UserConfig } from "vite";
 import { DtsCreator } from "typed-css-modules/lib/dts-creator.js";
 import fs from "fs";
 
-function plugin(): Plugin {
+export type TypedCssModulesOptions = {
+  fileExtension?: `.${string}`;
+}
+
+function plugin(options?: TypedCssModulesOptions): PluginOption {
   const creater = new DtsCreator({ camelCase: true });
 
   return {
@@ -18,8 +22,10 @@ function plugin(): Plugin {
       return config;
     },
     configureServer: (server) => {
+      const extension = options?.fileExtension ?? '.css';
+
       server.watcher.on("change", async (path) => {
-        if (!path.endsWith(".module.css")) return;
+        if (!path.endsWith(`.module${extension}`)) return;
         try {
           const content = await creater.create(path, undefined, true);
           await content.writeFile();
@@ -28,7 +34,7 @@ function plugin(): Plugin {
         }
       });
       server.watcher.on("unlink", (path) => {
-        if (!path.endsWith(".module.css")) return;
+        if (!path.endsWith(`.module${extension}`)) return;
         try {
           fs.unlinkSync(path + ".d.ts");
         } catch (e) {


### PR DESCRIPTION
Currently plugin supports only `.css` modules extensions.
This PR adds optional configurations for plugin allowing to change file extension. 

It is backward compatible as it is optional and the default is `.css`

example:
```
export default defineConfig({
  plugins: [react(), typedCssModulesPlugin({fileExtension: '.scss'})],
})
```