### PR TITLE
Ensure a relative paths are resolved relative to the vite project root, not the cwd

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -129,10 +129,12 @@ function plugin(options?: TypedCssModulesOptions): PluginOption {
     configResolved(config: ResolvedConfig) {
       viteConfig = config;
       filter = createFilter(include, options?.ignore, { resolve: config.root });
-      // If a rootDir is specified, resolve it to an absolute path relative to
-      // the Vite project root; otherwise, it would be resolved relative to the
-      // current working directory, which may be different.
-      rootDir = path.join(config.root, rootDir ?? "");
+      if (rootDir) {
+        // If a rootDir is specified, resolve it to an absolute path relative to
+        // the Vite project root; otherwise, it would be resolved relative to
+        // the current working directory, which may be different.
+        rootDir = path.join(config.root, rootDir);
+      }
     },
     async buildStart() {
       if (viteConfig) {


### PR DESCRIPTION
In reference to #9.

Ensure that all relative paths are resolved relative to the vite project root, not the current working directory. Without this change, the location of the generated declaration files can be different dependening the the current working directory if `rootDir` is specified. This is highly unexpected because the client would probably expect `rootDir` to be resolved relative to the project root. 